### PR TITLE
Remove `String` from the external API

### DIFF
--- a/brillo-examples/brillo-examples.cabal
+++ b/brillo-examples/brillo-examples.cabal
@@ -33,6 +33,7 @@ executable brillo-bitmap
   hs-source-dirs:   picture/Bitmap
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -47,6 +48,7 @@ executable brillo-boids
 
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
     , random  >=1.2    && <1.3
 
@@ -58,6 +60,7 @@ executable brillo-clock
   hs-source-dirs:   picture/Clock
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -68,6 +71,7 @@ executable brillo-color
   hs-source-dirs:   picture/Color
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -82,6 +86,7 @@ executable brillo-conway
 
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
     , random  >=1.2    && <1.3
     , vector  >=0.13   && <0.14
@@ -94,6 +99,7 @@ executable brillo-draw
   hs-source-dirs:   picture/Draw
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -105,6 +111,7 @@ executable brillo-dropfiles
   build-depends:
     , base    >=4.8    && <5
     , brillo  >=1.13.3 && <1.15
+    , text    >=2.1.2  && <2.2
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
 
@@ -114,6 +121,7 @@ executable brillo-easy
   hs-source-dirs:   picture/Easy
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -129,6 +137,7 @@ executable brillo-eden
 
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
     , random  >=1.2    && <1.3
 
@@ -140,6 +149,7 @@ executable brillo-flake
   hs-source-dirs:   picture/Flake
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -150,6 +160,7 @@ executable brillo-gameevent
   hs-source-dirs:   picture/GameEvent
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -160,6 +171,7 @@ executable brillo-hello
   hs-source-dirs:   picture/Hello
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -175,6 +187,7 @@ executable brillo-lifespan
 
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
     , random  >=1.2    && <1.3
 
@@ -196,6 +209,7 @@ executable brillo-machina
   hs-source-dirs:   picture/Machina
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -212,6 +226,7 @@ executable brillo-occlusion
 
   build-depends:
     , base               >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo             >=1.13.3 && <1.15
     , brillo-algorithms  >=1.13.3 && <1.15
 
@@ -224,6 +239,7 @@ executable brillo-pickfiles
   build-depends:
     , base    >=4.8    && <5
     , brillo  >=1.13.3 && <1.15
+    , text    >=2.1.2  && <2.2
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
 
@@ -242,6 +258,7 @@ executable brillo-styrene
 
   build-depends:
     , base        >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo      >=1.13.3 && <1.15
     , containers  >=0.5    && <0.8
 
@@ -253,6 +270,7 @@ executable brillo-tree
   hs-source-dirs:   picture/Tree
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -271,6 +289,7 @@ executable brillo-visibility
 
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
     , vector  >=0.13   && <0.14
 
@@ -282,6 +301,7 @@ executable brillo-zen
   hs-source-dirs:   picture/Zen
   build-depends:
     , base    >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo  >=1.13.3 && <1.15
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
@@ -295,6 +315,7 @@ executable brillo-graph
     , brillo      >=1.13.3 && <1.15
     , containers  >=0.5    && <0.8
     , random      >=1.2    && <1.3
+    , text        >=2.1.2  && <2.2
 
   ghc-options:      -O2 -Wall -threaded -rtsopts
 
@@ -313,6 +334,7 @@ executable brillo-render
   default-language: GHC2021
   build-depends:
     , base              >=4.8    && <5
+    , text    >=2.1.2  && <2.2
     , brillo            >=1.13.3 && <1.15
     , brillo-rendering  >=1.13.3 && <1.15
     , GLFW-b            >=3.3    && <4

--- a/brillo-examples/picture/Bitmap/Main.hs
+++ b/brillo-examples/picture/Bitmap/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Brillo
+import Data.Text qualified as T
 import System.Environment
 
 
@@ -27,7 +28,7 @@ run fileName =
 
     let (width, height) = bitmapSize bmpData
     animate
-      (InWindow fileName (width, height) (10, 10))
+      (InWindow (T.pack fileName) (width, height) (10, 10))
       black
       (frame width height picture)
 

--- a/brillo-examples/picture/Boids/Main.hs
+++ b/brillo-examples/picture/Boids/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- Implementation of the Boids flocking algorithm.
 --   by Matthew Sottile <matt@galois.com> <mjsottile@computer.org>
 --   Described in http://syntacticsalt.com/2011/03/10/functional-flocks/

--- a/brillo-examples/picture/Clock/Main.hs
+++ b/brillo-examples/picture/Clock/Main.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- A fractal consisting of circles and lines which looks a bit like
 --      the workings of a clock.
 module Main where
 
 import Brillo
+import Data.Text qualified as T
 import Prelude hiding (lines)
 
 
@@ -65,7 +68,7 @@ clockFractal n s = Pictures [circ1, circ2, circ3, lines]
               Color cyan $
                 Translate (-0.15) 1 $
                   Scale 0.001 0.001 $
-                    Text (show s)
+                    Text (T.show s)
             else Blank
         ]
 

--- a/brillo-examples/picture/Color/Main.hs
+++ b/brillo-examples/picture/Color/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ParallelListComp #-}
 
 -- Draw a color wheel.

--- a/brillo-examples/picture/Conway/Main.hs
+++ b/brillo-examples/picture/Conway/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Brillo

--- a/brillo-examples/picture/Draw/Main.hs
+++ b/brillo-examples/picture/Draw/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 
 {-| Simple picture drawing application.

--- a/brillo-examples/picture/DropFiles/Main.hs
+++ b/brillo-examples/picture/DropFiles/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Drag & drop files onto the window to load them
 module Main where
 
@@ -5,7 +7,7 @@ import Brillo
 import Brillo.Interface.Pure.Game
 import Data.Function ((&))
 import Data.Functor ((<&>))
-
+import Data.Text qualified as T
 
 width :: (Num a) => a
 width = 600
@@ -27,7 +29,7 @@ makePicture (State filePaths) =
     filePaths & zip [(1 :: Int) ..] <&> \(i, filePath) ->
       Translate (-width / 2) (fromIntegral (-25 * i) + (height / 2)) $
         Scale 0.1 0.1 $
-          Text filePath
+          Text $ T.pack filePath
 
 
 -- | Handle drag & drop events

--- a/brillo-examples/picture/Easy/Main.hs
+++ b/brillo-examples/picture/Easy/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Brillo

--- a/brillo-examples/picture/Eden/Main.hs
+++ b/brillo-examples/picture/Eden/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- Adapted from ANUPlot version by Clem Baker-Finch
 module Main where
 

--- a/brillo-examples/picture/Flake/Main.hs
+++ b/brillo-examples/picture/Flake/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 {-| Snowflake Fractal.
      Based on ANUPlot code by Clem Baker-Finch.
 -}

--- a/brillo-examples/picture/GameEvent/Main.hs
+++ b/brillo-examples/picture/GameEvent/Main.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Brillo
+import Data.Text qualified as T
 
 
 -- | Display the last event received as text.
@@ -12,5 +15,5 @@ main =
     100
     ""
     (\str -> Translate (-340) 0 $ Scale 0.1 0.1 $ Text str)
-    (\event _ -> show event)
+    (\event _ -> T.show event)
     (\_ world -> world)

--- a/brillo-examples/picture/Graph/Main.hs
+++ b/brillo-examples/picture/Graph/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- See <http://mazzo.li/posts/graph-drawing.html> for a lengthy
 -- explanation about this code.
 import Data.Map.Strict (Map)

--- a/brillo-examples/picture/Hello/Main.hs
+++ b/brillo-examples/picture/Hello/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | Display "Hello World" in a window.
 module Main where
 

--- a/brillo-examples/picture/Lifespan/Main.hs
+++ b/brillo-examples/picture/Lifespan/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- Adapted from ANUPlot version by Clem Baker-Finch
 module Main where
 

--- a/brillo-examples/picture/Lines/Main.hs
+++ b/brillo-examples/picture/Lines/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Brillo (

--- a/brillo-examples/picture/Machina/Main.hs
+++ b/brillo-examples/picture/Machina/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Brillo

--- a/brillo-examples/picture/Occlusion/Main.hs
+++ b/brillo-examples/picture/Occlusion/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 
 import Brillo.Data.Extent

--- a/brillo-examples/picture/PickFiles/Main.hs
+++ b/brillo-examples/picture/PickFiles/Main.hs
@@ -19,6 +19,8 @@ import Brillo.Interface.IO.Game (
  )
 import Data.Function ((&))
 import Data.Functor ((<&>))
+import Data.Text (Text)
+import Data.Text qualified as T
 
 
 size :: (Num width, Num height) => (width, height)
@@ -28,7 +30,7 @@ size = (600, 600)
 data State
   = NotAsked
   | Success [FilePath]
-  | Failure String
+  | Failure Text
 
 
 moveToTopLeftWithOffset :: Float -> Picture -> Picture
@@ -66,7 +68,7 @@ makePicture state =
             moveToTopLeftWithOffset 0 $
               Translate 10 (fromIntegral (-(25 * i))) $
                 Scale 0.1 0.1 $
-                  ThickText filePath 2
+                  ThickText (T.pack filePath) 2
 
 
 handleEvent :: Event -> State -> IO State

--- a/brillo-examples/picture/Styrene/Main.hs
+++ b/brillo-examples/picture/Styrene/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Actor (Actor (..))

--- a/brillo-examples/picture/Tree/Main.hs
+++ b/brillo-examples/picture/Tree/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 {-| Tree Fractal.
      Based on ANUPlot code by Clem Baker-Finch.
 -}

--- a/brillo-examples/picture/Visibility/Main.hs
+++ b/brillo-examples/picture/Visibility/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 {-| Visibility on the 2D plane.
   Uses an instance of Warnocks algorithm.
   TODO: animate the line segments, make them spin and move around so we can see

--- a/brillo-examples/picture/Zen/Main.hs
+++ b/brillo-examples/picture/Zen/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- A nifty animated fractal of a tree, superimposed on a background
 --      of three red rectangles.
 import Brillo

--- a/brillo-juicy/brillo-juicy.hs
+++ b/brillo-juicy/brillo-juicy.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main where
 
 import Brillo (

--- a/brillo-rendering/Brillo/Internals/Data/Picture.hs
+++ b/brillo-rendering/Brillo/Internals/Data/Picture.hs
@@ -38,6 +38,7 @@ import Codec.BMP (BMP, bmpDimensions, readBMP, unpackBMPToRGBA32)
 import Data.ByteString (ByteString)
 import Data.ByteString.Unsafe qualified as BSU
 import Data.Data (Data, Typeable)
+import Data.Text (Text)
 import Data.Word (Word8)
 import Foreign.ForeignPtr (ForeignPtr, newForeignPtr)
 import Foreign.Marshal.Alloc (finalizerFree, mallocBytes)
@@ -94,9 +95,9 @@ data Picture
     --   If the thickness is 0 then this is equivalent to `Arc`.
     ThickArc Float Float Float Float
   | -- | Text to draw with a vector font
-    Text String
+    Text Text
   | -- | Text to draw with a vector font and a given thickness.
-    ThickText String Float
+    ThickText Text Float
   | -- | A bitmap image.
     Bitmap BitmapData
   | -- | A subsection of a bitmap image where

--- a/brillo-rendering/brillo-rendering.cabal
+++ b/brillo-rendering/brillo-rendering.cabal
@@ -40,5 +40,6 @@ library
     , bytestring  >=0.11 && <0.13
     , containers  >=0.5  && <0.8
     , OpenGL      >=2.12 && <3.1
+    , text        >=2.1.2 && <2.2
 
   ghc-options:      -Wall -O2

--- a/brillo/Brillo/Data/Display.hs
+++ b/brillo/Brillo/Data/Display.hs
@@ -1,11 +1,13 @@
 module Brillo.Data.Display (Display (..))
 where
 
+import Data.Text (Text)
+
 
 -- | Describes how Brillo should display its output.
 data Display
   = -- | Display in a window with the given name, size and position.
-    InWindow String (Int, Int) (Int, Int)
+    InWindow Text (Int, Int) (Int, Int)
   | -- | Display full screen.
     FullScreen
   deriving (Eq, Read, Show)

--- a/brillo/Brillo/Data/Picture.hs
+++ b/brillo/Brillo/Data/Picture.hs
@@ -39,6 +39,7 @@ where
 
 import Brillo.Geometry.Angle
 import Brillo.Rendering
+import Data.Text (Text)
 
 
 -- Constructors ----------------------------------------------------------------
@@ -92,7 +93,7 @@ thickArc = ThickArc
 
 
 -- | Some text to draw with a vector font.
-text :: String -> Picture
+text :: Text -> Picture
 text = Text
 
 

--- a/brillo/Brillo/Internals/Interface/Backend/GLFW.hs
+++ b/brillo/Brillo/Internals/Interface/Backend/GLFW.hs
@@ -137,7 +137,7 @@ openWindowGLFW ref (InWindow title (sizeX, sizeY) pos) =
       GLFW.createWindow
         sizeX
         sizeY
-        title
+        (T.unpack title)
         Nothing
         Nothing
 

--- a/brillo/brillo.cabal
+++ b/brillo/brillo.cabal
@@ -56,6 +56,7 @@ library
     Brillo.Data.Vector
     Brillo.Data.ViewPort
     Brillo.Data.ViewState
+    Brillo.Geometry
     Brillo.Geometry.Angle
     Brillo.Geometry.Line
     Brillo.Interface.Environment


### PR DESCRIPTION
Closes #19.

Turns out this library doesn't really do anything interesting with text, so this is mostly just a lot of grunt work, and performance may not be affected at all in practice. For one thing, bytestrings are already used internally where important, e.g. for bitmaps.

There are some `T.unpack`s due to `GLFW`'s and `JuicyPixels`'s APIs disappointingly still using `String`. Other places where `String` remains internally are where we actually operate char-by-char, and for some stuff that just gets passed to `error`.

The lower bound on `text` is currently necessary due to `T.show`, but is inconsistent with the main `brillo` library now that I've rebased on top of eedbee1. We could just use `T.pack . show` instead...

An obvious follow-up to this would be to switch from `FilePath` to `OsPath`, since only then are we truly rid of `String`. I had intended to look at this as part of this same work, but I no longer see myself getting around to it any time soon.