### PR TITLE
Use FULE from Hackage to unstick CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -225,12 +225,6 @@ jobs:
           echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
           echo "package brillo-rendering" >> cabal.project
           echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
-          cat >> cabal.project <<EOF
-          source-repository-package
-            type: git
-            location: https://github.com/ad-si/FULE.git
-            tag: c2546b4a6c82ce2bc35d8b1ef1e558b0dd560e01
-          EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(brillo|brillo-algorithms|brillo-examples|brillo-export|brillo-juicy|brillo-rendering)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -225,6 +225,7 @@ jobs:
           echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
           echo "package brillo-rendering" >> cabal.project
           echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
+          echo "allow-newer: FULE:containers" >> cabal.project
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(brillo|brillo-algorithms|brillo-examples|brillo-export|brillo-juicy|brillo-rendering)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -5,8 +5,3 @@ packages:
   brillo-export
   brillo-juicy
   brillo-rendering
-
-source-repository-package
-  type: git
-  location: https://github.com/ad-si/FULE.git
-  tag: c2546b4a6c82ce2bc35d8b1ef1e558b0dd560e01

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,5 @@ packages:
   brillo-export
   brillo-juicy
   brillo-rendering
+
+allow-newer: FULE:containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,9 +18,7 @@ ghc-options:
 extra-deps:
   - storable-offset-0.1.0.0
   - webp-0.1.2.0
-
-  - github: ad-si/FULE
-    commit: c2546b4a6c82ce2bc35d8b1ef1e558b0dd560e01
+  - FULE-0.3.1.2
 
   - github: dpwiz/freetype2
     commit: d2acf926b5c448d8edd60e322862adcf2dbe9146

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,16 +19,12 @@ packages:
   original:
     hackage: webp-0.1.2.0
 - completed:
-    name: FULE
+    hackage: FULE-0.3.1.2@sha256:cc8fb1360afb3f8b3baae9bf7aa7fa1d024a6ea0e4042cacfe7b16debb5dde7c,2238
     pantry-tree:
-      sha256: 9f6e5b5fb12e050cc9b38c3bf9194b6ef738103cd0596346ecc5fa219dcb0725
-      size: 2557
-    sha256: c3efb2a0a1f826f19c56b537303221b8087049f0196f8ae9f4759b5006542341
-    size: 33036
-    url: https://github.com/ad-si/FULE/archive/c2546b4a6c82ce2bc35d8b1ef1e558b0dd560e01.tar.gz
-    version: 0.3.1.2
+      sha256: 7268edb90a9519e91001fde56863f1aa98712672b21a0d662ddc7f343c11d721
+      size: 2206
   original:
-    url: https://github.com/ad-si/FULE/archive/c2546b4a6c82ce2bc35d8b1ef1e558b0dd560e01.tar.gz
+    hackage: FULE-0.3.1.2
 - completed:
     name: freetype2
     pantry-tree:


### PR DESCRIPTION
## Summary
- Haskell-CI has been failing with `fatal: unable to access 'https://github.com/ad-si/FULE.git/': The requested URL returned error: 500` when cloning the git source-repository-package.
- FULE 0.3.1.2 on Hackage matches the pinned commit (ad-si fork is identical in source to upstream 0.3.1.2), so switch to the Hackage version.
- Updates `cabal.project`, `stack.yaml`, `stack.yaml.lock`, and removes the git source-repository heredoc from `.github/workflows/haskell-ci.yml`.

## Test plan
- [ ] Haskell-CI passes across the GHC matrix
- [ ] Build Tetris passes on Linux/macOS (Windows `happy` strip issue is a separate flake)